### PR TITLE
use opensearch-py directly as opensearch_dsl is deprecated

### DIFF
--- a/docs/advanced_usage_examples.rst
+++ b/docs/advanced_usage_examples.rst
@@ -230,7 +230,7 @@ Document index
 
     from django.conf import settings
     from django_opensearch_dsl import Document, Index, fields
-    from opensearch_dsl import analyzer
+    from opensearchpy import analyzer
 
     from books.models import Book
 
@@ -692,7 +692,7 @@ view set in the following way:
 
     # ...
 
-    from opensearch_dsl import (
+    from opensearchpy import (
         DateHistogramFacet,
         RangeFacet,
         TermsFacet,
@@ -779,7 +779,7 @@ as the two backends it replaces.
 
     # ...
 
-    from opensearch_dsl import (
+    from opensearchpy import (
         DateHistogramFacet,
         RangeFacet,
         TermsFacet,
@@ -2172,8 +2172,8 @@ The following example indicates Ngram analyzer/filter usage.
     from django.conf import settings
     from django_opensearch_dsl import Document, Index, fields
 
-    from opensearch_dsl import analyzer
-    from opensearch_dsl.analysis import token_filter
+    from opensearchpy import analyzer
+    from opensearchpy.analysis import token_filter
 
     from books.models import Book
 

--- a/docs/basic_usage_examples.rst
+++ b/docs/basic_usage_examples.rst
@@ -78,7 +78,7 @@ Sample document
 .. code-block:: python
 
     from django_opensearch_dsl import Document, Index, fields
-    from opensearch_dsl import analyzer
+    from opensearchpy import analyzer
 
     from books.models import Publisher
 

--- a/docs/misc_usage_examples.rst
+++ b/docs/misc_usage_examples.rst
@@ -27,7 +27,7 @@ Customize results as follows:
 .. code-block:: python
 
     from django_elasticsearch_dsl_drf.helpers import more_like_this
-    from opensearch_dsl.query import Q
+    from opensearchpy.query import Q
     from books.models import Book
     book = Book.objects.first()
     query = Q('bool', must_not=Q('term', **{'state.raw': 'cancelled'}))

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -389,7 +389,7 @@ Required imports
 
     from django.conf import settings
     from django_opensearch_dsl import Document, Index, fields
-    from opensearch_dsl import analyzer
+    from opensearchpy import analyzer
 
     from books.models import Book
 

--- a/examples/simple/search_indexes/documents/analyzers.py
+++ b/examples/simple/search_indexes/documents/analyzers.py
@@ -1,4 +1,4 @@
-from opensearch_dsl import analyzer
+from opensearchpy import analyzer
 from django_elasticsearch_dsl_drf.versions import ELASTICSEARCH_GTE_7_0
 
 __all__ = (

--- a/examples/simple/search_indexes/documents/location.py
+++ b/examples/simple/search_indexes/documents/location.py
@@ -3,7 +3,7 @@ from django_opensearch_dsl import Document, Index, fields
 from django_elasticsearch_dsl_drf.compat import KeywordField, StringField
 from django_elasticsearch_dsl_drf.analyzers import edge_ngram_completion
 from django_elasticsearch_dsl_drf.versions import ELASTICSEARCH_GTE_5_0
-from opensearch_dsl import analyzer
+from opensearchpy import analyzer
 
 from books.models import Location
 

--- a/examples/simple/search_indexes/viewsets/book/base.py
+++ b/examples/simple/search_indexes/viewsets/book/base.py
@@ -25,7 +25,7 @@ from django_elasticsearch_dsl_drf.viewsets import (
     BaseDocumentViewSet,
 )
 
-from opensearch_dsl import DateHistogramFacet, RangeFacet, A
+from opensearchpy import DateHistogramFacet, RangeFacet, A
 
 from ...documents import BookDocument
 from ...serializers import BookDocumentSimpleSerializer

--- a/examples/simple/search_indexes/viewsets/book/frontend.py
+++ b/examples/simple/search_indexes/viewsets/book/frontend.py
@@ -32,7 +32,7 @@ from django_elasticsearch_dsl_drf.viewsets import (
 )
 from django_elasticsearch_dsl_drf.pagination import PageNumberPagination
 
-from opensearch_dsl import DateHistogramFacet, RangeFacet
+from opensearchpy import DateHistogramFacet, RangeFacet
 
 from rest_framework.decorators import action
 

--- a/examples/simple/search_indexes/viewsets/book/permissions.py
+++ b/examples/simple/search_indexes/viewsets/book/permissions.py
@@ -33,7 +33,7 @@ from django_elasticsearch_dsl_drf.viewsets import (
 from django_elasticsearch_dsl_drf.pagination import PageNumberPagination
 from django_elasticsearch_dsl_drf.utils import EmptySearch
 
-from opensearch_dsl import DateHistogramFacet, RangeFacet
+from opensearchpy import DateHistogramFacet, RangeFacet
 
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated

--- a/examples/simple/search_indexes/viewsets/journal.py
+++ b/examples/simple/search_indexes/viewsets/journal.py
@@ -24,7 +24,7 @@ from django_elasticsearch_dsl_drf.viewsets import (
     BaseDocumentViewSet,
 )
 
-from opensearch_dsl import DateHistogramFacet, RangeFacet, A
+from opensearchpy import DateHistogramFacet, RangeFacet, A
 
 from ..documents import JournalDocument
 from ..serializers import JournalDocumentSerializer

--- a/setup.py
+++ b/setup.py
@@ -159,7 +159,7 @@ install_requires = [
     'six>=1.9',
     'django-nine>=0.2',
     'django-opensearch-dsl',
-    'opensearch-dsl',
+    'opensearch-py',
     'opensearch',
     'djangorestframework',
 ]

--- a/src/django_elasticsearch_dsl_drf/analyzers.py
+++ b/src/django_elasticsearch_dsl_drf/analyzers.py
@@ -1,8 +1,8 @@
 """
 Analyzers.
 """
-from opensearch_dsl import analyzer
-from opensearch_dsl.analysis import token_filter
+from opensearchpy import analyzer
+from opensearchpy.analysis import token_filter
 
 __title__ = 'django_elasticsearch_dsl_drf.analyzers'
 __author__ = 'Artur Barseghyan <artur.barseghyan@gmail.com>'

--- a/src/django_elasticsearch_dsl_drf/fields/helpers.py
+++ b/src/django_elasticsearch_dsl_drf/fields/helpers.py
@@ -1,7 +1,7 @@
 """
 Helpers.
 """
-from opensearch_dsl.utils import AttrDict, AttrList
+from opensearchpy.utils import AttrDict, AttrList
 
 __title__ = 'django_elasticsearch_dsl_drf.fields.helpers'
 __author__ = 'Artur Barseghyan <artur.barseghyan@gmail.com>'

--- a/src/django_elasticsearch_dsl_drf/filter_backends/faceted_search.py
+++ b/src/django_elasticsearch_dsl_drf/filter_backends/faceted_search.py
@@ -4,8 +4,8 @@ Faceted search backend.
 import copy
 from collections import defaultdict
 
-from opensearch_dsl import TermsFacet
-from opensearch_dsl.query import Q
+from opensearchpy import TermsFacet
+from opensearchpy.query import Q
 
 from rest_framework.filters import BaseFilterBackend
 
@@ -28,7 +28,7 @@ class FacetedSearchFilterBackend(BaseFilterBackend):
         >>> from django_elasticsearch_dsl_drf.filter_backends import (
         >>>     FacetedSearchFilterBackend
         >>> )
-        >>> from opensearch_dsl import TermsFacet, DateHistogramFacet
+        >>> from opensearchpy import TermsFacet, DateHistogramFacet
         >>> from django_elasticsearch_dsl_drf.viewsets import (
         >>>     BaseDocumentViewSet,
         >>> )

--- a/src/django_elasticsearch_dsl_drf/filter_backends/filtering/common.py
+++ b/src/django_elasticsearch_dsl_drf/filter_backends/filtering/common.py
@@ -4,7 +4,7 @@ Common filtering backend.
 
 import operator
 
-from opensearch_dsl.query import Q
+from opensearchpy.query import Q
 from rest_framework.filters import BaseFilterBackend
 from django_opensearch_dsl import fields
 

--- a/src/django_elasticsearch_dsl_drf/filter_backends/filtering/geo_spatial.py
+++ b/src/django_elasticsearch_dsl_drf/filter_backends/filtering/geo_spatial.py
@@ -22,7 +22,7 @@ The queries in this group are:
   polygon.
 """
 import logging
-from opensearch_dsl.query import Q
+from opensearchpy.query import Q
 from rest_framework.filters import BaseFilterBackend
 
 from six import string_types

--- a/src/django_elasticsearch_dsl_drf/filter_backends/filtering/nested.py
+++ b/src/django_elasticsearch_dsl_drf/filter_backends/filtering/nested.py
@@ -2,7 +2,7 @@
 Nested filtering backend.
 """
 
-from opensearch_dsl.query import Q
+from opensearchpy.query import Q
 from django.core.exceptions import ImproperlyConfigured
 from django_opensearch_dsl import fields
 

--- a/src/django_elasticsearch_dsl_drf/filter_backends/search/historical.py
+++ b/src/django_elasticsearch_dsl_drf/filter_backends/search/historical.py
@@ -6,7 +6,7 @@ import operator
 import warnings
 
 from django_opensearch_dsl import fields
-from opensearch_dsl.query import Q
+from opensearchpy.query import Q
 from rest_framework.filters import BaseFilterBackend
 from rest_framework.settings import api_settings
 import six

--- a/src/django_elasticsearch_dsl_drf/filter_backends/search/query_backends/match.py
+++ b/src/django_elasticsearch_dsl_drf/filter_backends/search/query_backends/match.py
@@ -1,4 +1,4 @@
-from opensearch_dsl.query import Q
+from opensearchpy.query import Q
 
 from .base import BaseSearchQueryBackend
 

--- a/src/django_elasticsearch_dsl_drf/filter_backends/search/query_backends/match_phrase.py
+++ b/src/django_elasticsearch_dsl_drf/filter_backends/search/query_backends/match_phrase.py
@@ -1,4 +1,4 @@
-from opensearch_dsl.query import Q
+from opensearchpy.query import Q
 
 from .base import BaseSearchQueryBackend
 

--- a/src/django_elasticsearch_dsl_drf/filter_backends/search/query_backends/match_phrase_prefix.py
+++ b/src/django_elasticsearch_dsl_drf/filter_backends/search/query_backends/match_phrase_prefix.py
@@ -1,4 +1,4 @@
-from opensearch_dsl.query import Q
+from opensearchpy.query import Q
 
 from .base import BaseSearchQueryBackend
 

--- a/src/django_elasticsearch_dsl_drf/filter_backends/search/query_backends/multi_match.py
+++ b/src/django_elasticsearch_dsl_drf/filter_backends/search/query_backends/multi_match.py
@@ -1,6 +1,6 @@
 import copy
 
-from opensearch_dsl.query import Q
+from opensearchpy.query import Q
 
 from .base import BaseSearchQueryBackend
 

--- a/src/django_elasticsearch_dsl_drf/filter_backends/search/query_backends/nested.py
+++ b/src/django_elasticsearch_dsl_drf/filter_backends/search/query_backends/nested.py
@@ -1,7 +1,7 @@
 import operator
 import six
 
-from opensearch_dsl.query import Q
+from opensearchpy.query import Q
 
 from .base import BaseSearchQueryBackend
 

--- a/src/django_elasticsearch_dsl_drf/filter_backends/search/query_backends/simple_query_string.py
+++ b/src/django_elasticsearch_dsl_drf/filter_backends/search/query_backends/simple_query_string.py
@@ -1,6 +1,6 @@
 import copy
 
-from opensearch_dsl.query import Q
+from opensearchpy.query import Q
 
 from .base import BaseSearchQueryBackend
 

--- a/src/django_elasticsearch_dsl_drf/filter_backends/suggester/functional.py
+++ b/src/django_elasticsearch_dsl_drf/filter_backends/suggester/functional.py
@@ -67,7 +67,7 @@ Example:
     >>>
     >>>         model = Publisher  # The model associate with this Document
 """
-from opensearch_dsl.search import AggsProxy
+from opensearchpy.search import AggsProxy
 
 from django_elasticsearch_dsl_drf.constants import (
     FUNCTIONAL_SUGGESTER_TERM_MATCH,

--- a/src/django_elasticsearch_dsl_drf/helpers.py
+++ b/src/django_elasticsearch_dsl_drf/helpers.py
@@ -5,9 +5,9 @@ from collections import OrderedDict
 
 from django_opensearch_dsl.registries import registry
 
-from opensearch_dsl import Search
-from opensearch_dsl.connections import connections
-from opensearch_dsl.query import MoreLikeThis
+from opensearchpy import Search
+from opensearchpy.connections import connections
+from opensearchpy.query import MoreLikeThis
 
 from six import PY3
 

--- a/src/django_elasticsearch_dsl_drf/pagination.py
+++ b/src/django_elasticsearch_dsl_drf/pagination.py
@@ -9,7 +9,7 @@ from collections import OrderedDict
 
 from django.core import paginator as django_paginator
 
-from opensearch_dsl.utils import AttrDict
+from opensearchpy.utils import AttrDict
 
 from rest_framework import pagination
 from rest_framework.exceptions import NotFound

--- a/src/django_elasticsearch_dsl_drf/utils.py
+++ b/src/django_elasticsearch_dsl_drf/utils.py
@@ -3,7 +3,7 @@ Utils.
 """
 
 import datetime
-from opensearch_dsl.search import AggsProxy
+from opensearchpy.search import AggsProxy
 
 
 __title__ = 'django_elasticsearch_dsl_drf.utils'

--- a/src/django_elasticsearch_dsl_drf/versions.py
+++ b/src/django_elasticsearch_dsl_drf/versions.py
@@ -26,7 +26,7 @@ def get_elasticsearch_version(default=(2, 0, 0)):
     :rtype: list
     """
     try:
-        from opensearch_dsl import __version__
+        from opensearchpy import __version__
         return __version__
     except ImportError:
         return default

--- a/src/django_elasticsearch_dsl_drf/viewsets.py
+++ b/src/django_elasticsearch_dsl_drf/viewsets.py
@@ -10,9 +10,9 @@ import copy
 from django.http import Http404
 from django.core.exceptions import ImproperlyConfigured
 
-from opensearch_dsl import Search
-from opensearch_dsl.connections import connections
-from opensearch_dsl.query import MoreLikeThis
+from opensearchpy import Search
+from opensearchpy.connections import connections
+from opensearchpy.query import MoreLikeThis
 
 from rest_framework import status
 from rest_framework.decorators import action


### PR DESCRIPTION
Might make sense to pull this to a new branch say `opensearchpy` so that is does not mess the current functionality of scoap3